### PR TITLE
Optionally submit some debugging details once for each request

### DIFF
--- a/logs_http.admin.inc
+++ b/logs_http.admin.inc
@@ -16,6 +16,13 @@ function logs_http_admin_settings($form, &$form_state) {
     '#default_value' => variable_get('logs_http_enabled', TRUE),
   );
 
+  $form['logs_http_debugging_mode'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Debugging mode'),
+    '#description' => t('If selected, each log entry will contain a lot more details about the current http request.'),
+    '#default_value' => variable_get('logs_http_debugging_mode', FALSE),
+  );
+
   $form['logs_http_url'] = array(
     '#type' => 'textfield',
     '#title' => t('Endpoint'),

--- a/logs_http.module
+++ b/logs_http.module
@@ -139,18 +139,33 @@ function logs_http_register_event(array $log_entry) {
     'severity' => $log_entry['severity'],
   );
 
-  if (!empty($log_entry['variables']['exception_trace'])) {
-    // @todo: We avoid unserializing as it seems to causes Logs to fail
-    // to index event as JSON.
-    $event['exception_trace'] = base64_decode($log_entry['variables']['exception_trace']);
-  }
-
   if ($uuid = variable_get('logs_http_uuid')) {
     $event['uuid'] = $uuid;
   }
 
   // Remove empty values, to prevent errors in the indexing of the JSON.
   $event = logs_http_array_remove_empty($event);
+
+  if (variable_get('logs_http_debugging_mode', FALSE)) {
+    if (!isset($events['debugging'])) {
+      $debugging_event = $event;
+      unset($debugging_event['type']);
+      unset($debugging_event['message']);
+      unset($debugging_event['severity']);
+      $debugging_event['debug_details'] = array(
+        'GET' => $_GET,
+        'POST' => $_POST,
+        'COOKIE' => $_COOKIE,
+      );
+      $events['debugging'] = $debugging_event;
+    }
+  }
+
+  if (!empty($log_entry['variables']['exception_trace'])) {
+    // @todo: We avoid unserializing as it seems to causes Logs to fail
+    // to index event as JSON.
+    $event['exception_trace'] = base64_decode($log_entry['variables']['exception_trace']);
+  }
 
   // Prevent identical events.
   $event_clone = $event;

--- a/logs_http.module
+++ b/logs_http.module
@@ -139,6 +139,12 @@ function logs_http_register_event(array $log_entry) {
     'severity' => $log_entry['severity'],
   );
 
+  if (!empty($log_entry['variables']['exception_trace'])) {
+    // @todo: We avoid unserializing as it seems to causes Logs to fail
+    // to index event as JSON.
+    $event['exception_trace'] = base64_decode($log_entry['variables']['exception_trace']);
+  }
+
   if ($uuid = variable_get('logs_http_uuid')) {
     $event['uuid'] = $uuid;
   }
@@ -146,12 +152,35 @@ function logs_http_register_event(array $log_entry) {
   // Remove empty values, to prevent errors in the indexing of the JSON.
   $event = logs_http_array_remove_empty($event);
 
+  // Avoid infinite loops when drupal_alter should ever issue new events.
+  static $alter_active;
+  if (empty($alter_active)) {
+    $alter_active = TRUE;
+    // Allow other modules to alter the event before being registered.
+    drupal_alter('logs_http_event', $event);
+    $alter_active = FALSE;
+  }
+
+  // Prevent identical events.
+  $event_clone = $event;
+  unset($event_clone['timestamp']);
+  $key = md5(serialize($event_clone));
+  $events[$key] = $event;
+}
+
+/**
+ * Implements hook_logs_http_event_alter().
+ */
+function logs_http_logs_http_event_alter(&$event) {
   if (variable_get('logs_http_debugging_mode', FALSE)) {
+    $events = &drupal_static('logs_http_events', array());
     if (!isset($events['debugging'])) {
       $debugging_event = $event;
-      unset($debugging_event['type']);
-      unset($debugging_event['message']);
-      unset($debugging_event['severity']);
+      foreach (array('type', 'message', 'severity', 'exception_trace') as $key) {
+        if (isset($debugging_event[$key])) {
+          unset($debugging_event[$key]);
+        }
+      }
       $debugging_event['debug_details'] = array(
         'GET' => $_GET,
         'POST' => $_POST,
@@ -160,18 +189,6 @@ function logs_http_register_event(array $log_entry) {
       $events['debugging'] = $debugging_event;
     }
   }
-
-  if (!empty($log_entry['variables']['exception_trace'])) {
-    // @todo: We avoid unserializing as it seems to causes Logs to fail
-    // to index event as JSON.
-    $event['exception_trace'] = base64_decode($log_entry['variables']['exception_trace']);
-  }
-
-  // Prevent identical events.
-  $event_clone = $event;
-  unset($event_clone['timestamp']);
-  $key = md5(serialize($event_clone));
-  $events[$key] = $event;
 }
 
 /**


### PR DESCRIPTION
See https://github.com/Gizra/logs_http/issues/4

I have implemented this in a way that the debugging details get only submitted once per HTTP request, so even if one request to Drupal generates multiple events, there will only be one single event with debugging details.

Also, complex data within the JSON command is possible according to this blog post https://www.loggly.com/blog/8-handy-tips-consider-logging-json but only if the same field (here: "debug_details") has not been used for strings before. I have tested this and can confirm that it works as described.
