### PR TITLE
Update types and severities according to Drupal nomenclature

### DIFF
--- a/src/Logger/LogsHttpLogger.php
+++ b/src/Logger/LogsHttpLogger.php
@@ -107,7 +107,7 @@ class LogsHttpLogger implements LogsHttpLoggerInterface {
       'link' => strip_tags($context['link']),
       'message' => $message,
       'severity' => $this->severityLevels[$level]->getUntranslatedString(),
-      'severity_code' => $this->severityLevels[$level],
+      'severity_level' => $level,
     ];
 
     if (!empty($context['exception_trace'])) {

--- a/src/Logger/LogsHttpLogger.php
+++ b/src/Logger/LogsHttpLogger.php
@@ -99,14 +99,15 @@ class LogsHttpLogger implements LogsHttpLoggerInterface {
 
     $event = [
       'timestamp' => $context['timestamp'],
-      'type' => $this->severityLevels[$level]->getUntranslatedString(),
+      'type' => $context['channel'],
       'ip' => $context['ip'],
       'request_uri' => $context['request_uri'],
       'referer' => $context['referer'],
       'uid' => $context['uid'],
       'link' => strip_tags($context['link']),
       'message' => $message,
-      'severity' => $level,
+      'severity' => $this->severityLevels[$level]->getUntranslatedString(),
+      'severity_code' => $this->severityLevels[$level],
     ];
 
     if (!empty($context['exception_trace'])) {


### PR DESCRIPTION
In Drupal, `type` is a value such as `access denied`, `cron` or `user`; 
`severity` is a value such as `Emergency`, `Alert`, `Debug`, etc, which are mapped to an ENUM, and can be translated to an integer value representing the severity. You can see this information in the Recent Log Messages pages in the reports menu.

In this plugin:
- `type` is the string representing the Drupal `severity`
- `severity` is the value representing the Drupal `severity`
- `Drupal severity`(as explained in the first lines) is nowhere to be found :(

With this commit, maybe it's a bit of breaking changes, but this way the nomenclature matches to the one in Drupal, plus we expose the `Drupal severity`, which is quite useful, for example in 404 cases, as we are only getting something like `Notice` but we don't know what exactly, just a URL in the message.

Because maybe someone would still need the `severity` in integer value, I added it in another attribute called `severity_level`.

Hope you can find it useful!
