### PR TITLE
7.x - Alter hook for requests + hook for failed requests.

### DIFF
--- a/logs_http.admin.inc
+++ b/logs_http.admin.inc
@@ -19,6 +19,7 @@ function logs_http_admin_settings($form, &$form_state) {
   $form['logs_http_url'] = array(
     '#type' => 'textfield',
     '#title' => t('Endpoint'),
+    '#maxlength' => 2000,
     '#description' => t('The URL to POST the data to.'),
     '#default_value' => variable_get('logs_http_url', NULL),
   );

--- a/logs_http.module
+++ b/logs_http.module
@@ -98,16 +98,27 @@ function logs_http_shutdown() {
   }
 
   $url = logs_http_get_http_url();
-
+  $requests = array();
   // Send events to logs.
   foreach ($events as $event) {
-    $options = array(
-      'method' => 'POST',
+    $requests[] = array(
+      'event' => $event,
       'data' => drupal_json_encode($event),
     );
+  }
 
-    // Send data to Logs.
+  drupal_alter('logs_http_requests', $requests);
+
+  foreach ($requests as $key => $request) {
+    $options = array(
+      'method' => 'POST',
+      'data' => $request['data'],
+    );
     $response = drupal_http_request($url, $options);
+
+    if ($response->code != '200') {
+      module_invoke_all('logs_http_error', $response);
+    }
   }
 }
 

--- a/logs_http.module
+++ b/logs_http.module
@@ -117,7 +117,10 @@ function logs_http_shutdown() {
     $response = drupal_http_request($url, $options);
 
     if ($response->code != '200') {
-      module_invoke_all('logs_http_error', $response);
+      module_invoke_all('logs_http_request_error', $response);
+    }
+    else {
+      module_invoke_all('logs_http_request_success', $response);
     }
   }
 }


### PR DESCRIPTION
This is a pull request that emerged from the need to perform the following tasks:

a) Alter the log service requests from custom modules.
b) Provide a means to create alerts whenever the log service requests fail.
c) Add support for URLs that exceed the built-in 255-character limit on the Endpoint field.

Let me know if it requires any adjustments.