### PR TITLE
Don't futz so much with the exception string

### DIFF
--- a/logs_http.module
+++ b/logs_http.module
@@ -54,9 +54,6 @@ function _logs_http_exception_handler($exception) {
 function _logs_http_decode_exception($exception) {
   $return = Error::decodeException($exception);
 
-  // We have to serialize and encode the array here to prevent a notice in
-  // theme_dblog_message(). We will decode the string back in
-  // logs_http_watchdog()
   $return['exception_trace'] = $exception->getTraceAsString();
 
   return $return;

--- a/logs_http.module
+++ b/logs_http.module
@@ -5,8 +5,6 @@
  * Logs HTTP module.
  */
 
-use Drupal\Component\Serialization\Json;
-use Drupal\Component\Utility\Crypt;
 use Drupal\Core\Utility\Error;
 use Drupal\logs_http\Logger\LogsHttpLogger;
 
@@ -27,7 +25,7 @@ function _logs_http_exception_handler($exception) {
 
   try {
     // Log the message to the watchdog and return an error page to the user.
-    _drupal_log_error(_logs_http_decode_exception($exception), TRUE);
+    _drupal_log_error(Error::decodeException($exception), TRUE);
   }
     // PHP 7 introduces Throwable, which covers both Error and
     // Exception throwables.
@@ -38,25 +36,6 @@ function _logs_http_exception_handler($exception) {
   catch (\Exception $exception2) {
     _drupal_exception_handler_additional($exception, $exception2);
   }
-}
-
-/**
- * Decodes an exception and retrieves the correct caller.
- *
- * @param $exception
- *   The exception object that was thrown.
- *
- * @return array
- *   An error in the format expected by _drupal_log_error().
- *
- * @see _drupal_decode_exception()
- */
-function _logs_http_decode_exception($exception) {
-  $return = Error::decodeException($exception);
-
-  $return['exception_trace'] = $exception->getTraceAsString();
-
-  return $return;
 }
 
 /**

--- a/logs_http.module
+++ b/logs_http.module
@@ -32,10 +32,6 @@ function _logs_http_exception_handler($exception) {
   catch (\Throwable $error) {
     _drupal_exception_handler_additional($exception, $error);
   }
-    // In order to be compatible with PHP 5 we also catch regular Exceptions.
-  catch (\Exception $exception2) {
-    _drupal_exception_handler_additional($exception, $exception2);
-  }
 }
 
 /**

--- a/logs_http.module
+++ b/logs_http.module
@@ -57,7 +57,7 @@ function _logs_http_decode_exception($exception) {
   // We have to serialize and encode the array here to prevent a notice in
   // theme_dblog_message(). We will decode the string back in
   // logs_http_watchdog()
-  $return['exception_trace'] = Crypt::hashBase64(serialize($exception->getTrace()));
+  $return['exception_trace'] = $exception->getTraceAsString();
 
   return $return;
 }

--- a/src/Logger/LogsHttpLogger.php
+++ b/src/Logger/LogsHttpLogger.php
@@ -109,8 +109,8 @@ class LogsHttpLogger implements LogsHttpLoggerInterface {
       'severity' => $level,
     ];
 
-    if (!empty($context['exception_trace'])) {
-      $event['exception_trace'] = $context['exception_trace'];
+    if (!empty($context['@backtrace_string'])) {
+      $event['exception_trace'] = $context['@backtrace_string'];
     }
 
     if ($environment_uuid = $this->config->get('environment_uuid')) {

--- a/src/Logger/LogsHttpLogger.php
+++ b/src/Logger/LogsHttpLogger.php
@@ -110,9 +110,7 @@ class LogsHttpLogger implements LogsHttpLoggerInterface {
     ];
 
     if (!empty($context['exception_trace'])) {
-      // We avoid unserializing as it seems to causes Logs to fail to index
-      // event as JSON.
-      $event['exception_trace'] = base64_decode($context['exception_trace']);
+      $event['exception_trace'] = $context['exception_trace'];
     }
 
     if ($environment_uuid = $this->config->get('environment_uuid')) {


### PR DESCRIPTION
The code assumes it can serialize an object when logging an exception. If this object contains services like the database then this is going to trigger an exception.

This can be avoid by getting the trace as a string. The other benefit of this is then the exception trace will not be serialized PHP in the log server you send it to.