### PR TITLE
Cleaner register events API

### DIFF
--- a/src/Logger/LogsHttpLogger.php
+++ b/src/Logger/LogsHttpLogger.php
@@ -66,6 +66,11 @@ class LogsHttpLogger implements LogsHttpLoggerInterface {
    * {@inheritdoc}
    */
   public function log($level, $message, array $context = []) {
+    if (!$this->isEnabled()) {
+      // Service is disabled.
+      return;
+    }
+
     if ($level > $this->config->get('severity_level')) {
       // Severity level is above the ones we want to log.
       return;
@@ -88,11 +93,6 @@ class LogsHttpLogger implements LogsHttpLoggerInterface {
    * needed.
    */
   public function registerEvent($level, string $message, array $context = []) {
-    if (!$this->isEnabled()) {
-      // Service is disabled.
-      return [];
-    }
-
     // Populate the message placeholders and then replace them in the message.
     $message_placeholders = $this->logMessageParser->parseMessagePlaceholders($message, $context);
     $message = empty($message_placeholders) ? $message : strtr($message, $message_placeholders);

--- a/src/Logger/LogsHttpLogger.php
+++ b/src/Logger/LogsHttpLogger.php
@@ -140,9 +140,13 @@ class LogsHttpLogger implements LogsHttpLoggerInterface {
     $event_clone = $event;
     unset($event_clone['timestamp']);
     $key = md5(serialize($event_clone));
-    $this->cache[$key] = $event;
-  }
 
+    $is_unique = !empty($this->cache[$key]);
+
+    $this->cache[$key] = $event;
+
+    return $is_unique;
+  }
 
   /**
    * Deep array filter; Remove empty values.

--- a/src/Logger/LogsHttpLoggerInterface.php
+++ b/src/Logger/LogsHttpLoggerInterface.php
@@ -28,7 +28,7 @@ interface LogsHttpLoggerInterface extends LoggerInterface {
    *     return [];
    *   }
    *
-   *   // Update out custom value(s).
+   *   // Update our custom value(s).
    *   $event['foo'] = 'bar';
    *
    *   return $event;

--- a/src/Logger/LogsHttpLoggerInterface.php
+++ b/src/Logger/LogsHttpLoggerInterface.php
@@ -24,8 +24,8 @@ interface LogsHttpLoggerInterface extends LoggerInterface {
    * public function registerEvent($level, string $message, array $context = []) {
    *   $event = parent::registerEvent($level, $message, $context);
    *   if (empty($event)) {
-   *      Service is disabled.
-   *      return [];
+   *     Service is disabled.
+   *     return [];
    *   }
    *
    *   // Update out custom value(s).

--- a/src/Logger/LogsHttpLoggerInterface.php
+++ b/src/Logger/LogsHttpLoggerInterface.php
@@ -17,12 +17,40 @@ interface LogsHttpLoggerInterface extends LoggerInterface {
   /**
    * Register an event in the cache.
    *
+   * Modules extending this service, in need for different data to be added
+   * to the event will likely override this method in the following way:
+   *
+   * @code
+   * public function registerEvent($level, string $message, array $context = []) {
+   *   $event = parent::registerEvent($level, $message, $context);
+   *   if (empty($event)) {
+   *      Service is disabled.
+   *      return [];
+   *   }
+   *
+   *   // Update out custom value(s).
+   *   $event['foo'] = 'bar';
+   *
+   *   return $event;
+   * }
+   * @endcode
+   *
    * @param int $level
    *   The severity level.
    * @param string $message
    *   The message that contains the placeholders.
    * @param array $context
    *   The context as passed from the main Logger.
+   *
+   * @return array
+   *   If no event was created, since the service is disabled, then an empty
+   *   array. Otherwise an array with the following values:
+   *   - hash: The hash of the event. This is a result of md5, and it's just a
+   *   quick way for us to make sure we don't send over duplicate events
+   *   occurred in a single request.
+   *   - event: The array of the event.
+   *   - is_unique: TRUE indicating if this is the first time we encounter
+   *   this event in this specific request. Otherwise, if duplicate, FALSE.
    */
   public function registerEvent($level, string $message, array $context = []);
 

--- a/src/Logger/LogsHttpLoggerInterface.php
+++ b/src/Logger/LogsHttpLoggerInterface.php
@@ -24,7 +24,7 @@ interface LogsHttpLoggerInterface extends LoggerInterface {
    * public function registerEvent($level, string $message, array $context = []) {
    *   $event = parent::registerEvent($level, $message, $context);
    *   if (empty($event)) {
-   *     Service is disabled.
+   *     // Service is disabled.
    *     return [];
    *   }
    *

--- a/src/Logger/LogsHttpLoggerInterface.php
+++ b/src/Logger/LogsHttpLoggerInterface.php
@@ -39,14 +39,7 @@ interface LogsHttpLoggerInterface extends LoggerInterface {
    *   The context as passed from the main Logger.
    *
    * @return array
-   *   If no event was created, since the service is disabled, then an empty
-   *   array. Otherwise an array with the following values:
-   *   - hash: The hash of the event. This is a result of md5, and it's just a
-   *   quick way for us to make sure we don't send over duplicate events
-   *   occurred in a single request.
-   *   - event: The array of the event.
-   *   - is_unique: TRUE indicating if this is the first time we encounter
-   *   this event in this specific request. Otherwise, if duplicate, FALSE.
+   *   The event that was created.
    */
   public function registerEvent($level, string $message, array $context = []);
 

--- a/src/Logger/LogsHttpLoggerInterface.php
+++ b/src/Logger/LogsHttpLoggerInterface.php
@@ -23,10 +23,6 @@ interface LogsHttpLoggerInterface extends LoggerInterface {
    * @code
    * public function registerEvent($level, string $message, array $context = []) {
    *   $event = parent::registerEvent($level, $message, $context);
-   *   if (empty($event)) {
-   *     // Service is disabled.
-   *     return [];
-   *   }
    *
    *   // Update our custom value(s).
    *   $event['foo'] = 'bar';

--- a/src/Logger/LogsHttpLoggerInterface.php
+++ b/src/Logger/LogsHttpLoggerInterface.php
@@ -39,7 +39,7 @@ interface LogsHttpLoggerInterface extends LoggerInterface {
    *   The context as passed from the main Logger.
    *
    * @return array
-   *   The event that was created.
+   *   The event that was created, before it's added to the static cache.
    */
   public function registerEvent($level, string $message, array $context = []);
 


### PR DESCRIPTION
@justafish I had a look at https://github.com/justafish/drupal_datadog/blob/6a53f45ab8685b18a44990242532828e44f1e4f9/src/DatadogLogsHttpLogger.php#L21-L40

It seems we can improve the API of this module, so you'rs will be shorter. See code in https://github.com/Gizra/logs_http/compare/phpcs-fixes...cleaner-register-events?expand=1#diff-a8980919515a730454c410ee223daef28a355d2bba54688ad74a906858c96908R24

Will that work for you?
